### PR TITLE
Add workaround to fix decoding of nested structs

### DIFF
--- a/lib/docusign/request_builder.ex
+++ b/lib/docusign/request_builder.ex
@@ -143,7 +143,17 @@ defmodule DocuSign.RequestBuilder do
   def decode(%Tesla.Env{status: status} = env, false) when status in 200..299, do: {:ok, env}
 
   def decode(%Tesla.Env{status: status, body: body}, struct) when status in 200..299 do
-    Poison.decode(body, as: struct)
+    options = %{as: struct}
+
+    value =
+      body
+      |> Poison.Parser.parse!(options)
+      |> Poison.Decode.transform(options)
+
+    {:ok, value}
+  rescue
+    exception in [Poison.ParseError, Poison.DecodeError] ->
+      {:error, exception}
   end
 
   def decode(response, _struct), do: {:error, response}


### PR DESCRIPTION
Poison has a bug when using `Poison.decode!/2` with automatic conversion to structs that causes the `Poison.Decoder` protocol for the corresponding struct to be called twice. What ends up happening with the DocuSign models is that the second decode (using default values for the struct) overwrites the ones coming for the response.

This workaround avoids calling the `Poison.Decoder` protocol a second time.

For more information see: https://github.com/devinus/poison/issues/191